### PR TITLE
Fix incorrect run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Take a look at the [contributing](CONTRIBUTING.md) guide lines.
 To save the code you will need to download the app. Everything will be reset every time the command below is launched.
 
 ```bash
-curl -s https://raw.githubusercontent.com/JdeRobotbt-studio//main/scripts/run.sh | sudo bash
+curl -s https://raw.githubusercontent.com/JdeRobot/bt-studio/main/scripts/run.sh | sudo bash
 ```
 
 ### Developer


### PR DESCRIPTION

The README contained an incorrect command for running the script. The GitHub URL was malformed, leading to a `404 Not Found` error. This PR fixes the command by correcting the repository URL.  

#### **Original (Incorrect) Command:**  
```bash
curl -s https://raw.githubusercontent.com/JdeRobotbt-studio//main/scripts/run.sh | sudo bash
```

#### **Updated (Correct) Command:**  
```bash
curl -s https://raw.githubusercontent.com/JdeRobot/bt-studio/main/scripts/run.sh | sudo bash
```
