### PR TITLE
feat: add binary file support to get_file and zip helpers

### DIFF
--- a/frontend/src/api_helper/TreeWrapper.ts
+++ b/frontend/src/api_helper/TreeWrapper.ts
@@ -676,21 +676,28 @@ const createAction = async (
 const getFile = async (
   projectId: string,
   fileName: string,
-  universeName: string | undefined = undefined
+  universeName: string | undefined = undefined,
+  binary?: boolean
 ) => {
   if (!projectId) throw new Error("Project name is not set");
   if (!fileName) throw new Error("File name is not set");
 
   let apiUrl = `/bt_studio/get_file?project_id=${encodeURIComponent(projectId)}&filename=${encodeURIComponent(fileName)}`;
 
-  if (universeName !== undefined)
+  if (universeName !== undefined && universeName !== "")
     apiUrl += `&universe=${encodeURIComponent(universeName)}`;
+
+  if (binary) apiUrl += `&binary=true`;
 
   const response = await axios.get(apiUrl);
 
   // Handle unsuccessful response status (e.g., non-2xx status)
   if (!isSuccessful(response)) {
     throw new Error(response.data.message || "Failed to get file list."); // Response error
+  }
+
+  if (binary) {
+    return atob(response.data.content);
   }
 
   return response.data.content;

--- a/frontend/src/components/Buttons/Download.tsx
+++ b/frontend/src/components/Buttons/Download.tsx
@@ -106,11 +106,10 @@ const DownloadButton = ({ project }: { project: string }) => {
 
   const zipCodeFile = async (
     zip: JSZip,
-    file_path: string,
-    file_name: string,
+    file: Entry,
   ) => {
-    const content = await getFile(project, file_path);
-    zip.file(file_name, content);
+    const content = await getFile(project, file.path, undefined, file.binary);
+    zip.file(file.name, content, { binary: file.binary });
   };
 
   const zipCodeFolder = async (zip: JSZip, file: Entry) => {
@@ -125,7 +124,7 @@ const DownloadButton = ({ project }: { project: string }) => {
       if (element.is_dir) {
         await zipCodeFolder(folder, element);
       } else {
-        await zipCodeFile(folder, element.path, element.name);
+        await zipCodeFile(folder, element);
       }
     }
   };

--- a/frontend/src/components/Buttons/Download.tsx
+++ b/frontend/src/components/Buttons/Download.tsx
@@ -104,10 +104,7 @@ const DownloadButton = ({ project }: { project: string }) => {
     }
   };
 
-  const zipCodeFile = async (
-    zip: JSZip,
-    file: Entry,
-  ) => {
+  const zipCodeFile = async (zip: JSZip, file: Entry) => {
     const content = await getFile(project, file.path, undefined, file.binary);
     zip.file(file.name, content, { binary: file.binary });
   };

--- a/frontend/src/components/Buttons/Export.tsx
+++ b/frontend/src/components/Buttons/Export.tsx
@@ -97,10 +97,7 @@ const ExportButton = ({ project }: { project: string }) => {
     }
   };
 
-  const zipCodeFile = async (
-    zip: JSZip,
-    file: Entry,
-  ) => {
+  const zipCodeFile = async (zip: JSZip, file: Entry) => {
     const content = await getFile(project, file.path, undefined, file.binary);
     zip.file(file.name, content, { binary: file.binary });
   };

--- a/frontend/src/components/Buttons/Export.tsx
+++ b/frontend/src/components/Buttons/Export.tsx
@@ -99,11 +99,10 @@ const ExportButton = ({ project }: { project: string }) => {
 
   const zipCodeFile = async (
     zip: JSZip,
-    file_path: string,
-    file_name: string,
+    file: Entry,
   ) => {
-    const content = await getFile(project, file_path);
-    zip.file(file_name, content);
+    const content = await getFile(project, file.path, undefined, file.binary);
+    zip.file(file.name, content, { binary: file.binary });
   };
 
   const zipCodeFolder = async (zip: JSZip, file: Entry) => {
@@ -118,7 +117,7 @@ const ExportButton = ({ project }: { project: string }) => {
       if (element.is_dir) {
         await zipCodeFolder(folder, element);
       } else {
-        await zipCodeFile(folder, element.path, element.name);
+        await zipCodeFile(folder, element);
       }
     }
   };

--- a/frontend/src/components/Buttons/PlayPause.tsx
+++ b/frontend/src/components/Buttons/PlayPause.tsx
@@ -199,11 +199,10 @@ const PlayPauseButton = ({
 
   const zipCodeFile = async (
     zip: JSZip,
-    file_path: string,
-    file_name: string,
+    file: Entry,
   ) => {
-    const content = await getFile(project, file_path);
-    zip.file(file_name, content);
+    const content = await getFile(project, file.path, undefined, file.binary);
+    zip.file(file.name, content, { binary: file.binary });
   };
 
   const zipCodeFolder = async (zip: JSZip, file: Entry) => {
@@ -218,7 +217,7 @@ const PlayPauseButton = ({
       if (element.is_dir) {
         await zipCodeFolder(folder, element);
       } else {
-        await zipCodeFile(folder, element.path, element.name);
+        await zipCodeFile(folder, element);
       }
     }
   };

--- a/frontend/src/components/Buttons/PlayPause.tsx
+++ b/frontend/src/components/Buttons/PlayPause.tsx
@@ -197,10 +197,7 @@ const PlayPauseButton = ({
     }
   };
 
-  const zipCodeFile = async (
-    zip: JSZip,
-    file: Entry,
-  ) => {
+  const zipCodeFile = async (zip: JSZip, file: Entry) => {
     const content = await getFile(project, file.path, undefined, file.binary);
     zip.file(file.name, content, { binary: file.binary });
   };

--- a/frontend/src/components/Editors/Editors.ts
+++ b/frontend/src/components/Editors/Editors.ts
@@ -12,9 +12,9 @@ export const editorApi: ExtraApi = {
   file: {
     get: (project: string, file: Entry) => {
       if (file.group === "Universes") {
-        return getFile(project, file.path, "");
+        return getFile(project, file.path, "", file.binary);
       }
-      return getFile(project, file.path);
+      return getFile(project, file.path, undefined, file.binary);
     },
     save: (project: string, file: Entry, content: string) => {
       if (file.group === "Universes") {

--- a/frontend/src/components/ProjectsMenu/ProjectEntry.tsx
+++ b/frontend/src/components/ProjectsMenu/ProjectEntry.tsx
@@ -285,10 +285,7 @@ const Actions = ({ project }: { project: string }) => {
     }
   };
 
-  const zipCodeFile = async (
-    zip: JSZip,
-    file: Entry,
-  ) => {
+  const zipCodeFile = async (zip: JSZip, file: Entry) => {
     const content = await getFile(project, file.path, undefined, file.binary);
     zip.file(file.name, content, { binary: file.binary });
   };

--- a/frontend/src/components/ProjectsMenu/ProjectEntry.tsx
+++ b/frontend/src/components/ProjectsMenu/ProjectEntry.tsx
@@ -287,11 +287,10 @@ const Actions = ({ project }: { project: string }) => {
 
   const zipCodeFile = async (
     zip: JSZip,
-    file_path: string,
-    file_name: string,
+    file: Entry,
   ) => {
-    const content = await getFile(project, file_path);
-    zip.file(file_name, content);
+    const content = await getFile(project, file.path, undefined, file.binary);
+    zip.file(file.name, content, { binary: file.binary });
   };
 
   const zipCodeFolder = async (zip: JSZip, file: Entry) => {
@@ -306,7 +305,7 @@ const Actions = ({ project }: { project: string }) => {
       if (element.is_dir) {
         await zipCodeFolder(folder, element);
       } else {
-        await zipCodeFile(folder, element.path, element.name);
+        await zipCodeFile(folder, element);
       }
     }
   };

--- a/frontend/src/contexts/BtThemeContext.tsx
+++ b/frontend/src/contexts/BtThemeContext.tsx
@@ -4,7 +4,6 @@ import { createContext, ReactNode, useContext, useState } from "react";
 import { BtTheme } from "BtTypes/index";
 import { flushSync } from "react-dom";
 
-
 interface BtThemeProviderProps {
   theme?: BtTheme;
   children?: ReactNode;

--- a/frontend/src/styles/App.styles.tsx
+++ b/frontend/src/styles/App.styles.tsx
@@ -26,7 +26,8 @@ export const StyledAppContainer = styled.div<StyledAppContainerProps>`
 
   --shadow: inset 0 1px 2px #ffffff30, 0 1px 2px #00000030, 0 2px 4px #00000015;
 
-  &.h1, h1 {
+  &.h1,
+  h1 {
     font-size: 2rem;
     font-weight: 700;
     line-height: 1.5;
@@ -37,7 +38,8 @@ export const StyledAppContainer = styled.div<StyledAppContainerProps>`
     font-size: 18px;
   }
 
-  &.h3, h3 {
+  &.h3,
+  h3 {
     font-size: 1.17em;
     font-weight: bold;
     line-height: 1.5;


### PR DESCRIPTION

*   **Archivo modificado:** [TreeWrapper.ts](file:///home/konki/Documents/jdrobitcs/unibotics-webserver/unibotics/static/BtStudio/frontend/src/api_helper/TreeWrapper.ts)
    *   Se actualizó la función `getFile` para aceptar un parámetro opcional `binary?: boolean`. 
    *   Si es verdadero, añade `&binary=true` a la llamada HTTP y decodifica el Base64 resultante usando `atob` antes de retornar el contenido.
*   **Archivos de componentes modificados:**
    *   [PlayPause.tsx](file:///home/konki/Documents/jdrobitcs/unibotics-webserver/unibotics/static/BtStudio/frontend/src/components/Buttons/PlayPause.tsx)
    *   [Download.tsx](file:///home/konki/Documents/jdrobitcs/unibotics-webserver/unibotics/static/BtStudio/frontend/src/components/Buttons/Download.tsx)
    *   [Export.tsx](file:///home/konki/Documents/jdrobitcs/unibotics-webserver/unibotics/static/BtStudio/frontend/src/components/Buttons/Export.tsx)
    *   [ProjectEntry.tsx](file:///home/konki/Documents/jdrobitcs/unibotics-webserver/unibotics/static/BtStudio/frontend/src/components/ProjectsMenu/ProjectEntry.tsx)
    *   **Cambio:** Se modificó la firma de `zipCodeFile` para aceptar el objeto `Entry` completo de cada archivo (en lugar de solo la ruta e identificador) para así poder acceder a `file.binary`. Se pasa `file.binary` a `getFile` y se configura la opción `{ binary: file.binary }` al añadir el archivo al `.zip` de JSZip.
*   **Archivo de editor modificado:** [Editors.ts](file:///home/konki/Documents/jdrobitcs/unibotics-webserver/unibotics/static/BtStudio/frontend/src/components/Editors/Editors.ts)
    *   Se actualizó la lectura de archivos `editorApi.file.get` para propagar el flag `file.binary` al cargarse archivos del editor.